### PR TITLE
Fix incorrect ranking when the hand consists of only high cards.

### DIFF
--- a/src/combination/index.js
+++ b/src/combination/index.js
@@ -67,8 +67,8 @@ class Combination {
 		if(highestCardComparison !== 0) {
 			return highestCardComparison;
 		}
-		const thisCards = this.cards;
-		const combCards = combination.cards;
+		const thisCards = this._hand.cards;
+		const combCards = combination._hand.cards;
 		for(let i = thisCards.length - 1; i >= 0; i--) {
 			const cardComparison = thisCards[i].compare(combCards[i]);
 			if(cardComparison !== 0) {

--- a/test/hands-collection.js
+++ b/test/hands-collection.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const Card = require('../src/card');
 const Combination = require('../src/combination');
 const HandsCollection = require('../src/hands-collection');
 const HandDataBuilder = require('./dataBuilder/HandDataBuilder');
@@ -22,6 +23,15 @@ describe('Hands combinations', () => {
 		const collection = HandsCollection.createCombinations(board, hand);
 		
 		assert(collection.highestCombination.isFlush());
+	});
+
+	it('Highest combination with only high cards', () => {
+		const board = boardBuilder.build()
+		const hand = new HandDataBuilder().withCardsOfSpades(7, 8).build()
+
+		const cards = HandsCollection.createCombinations(board, hand).highestCombination._hand.cards
+		assert.notStrictEqual(cards[0], new Card(23, 5))
+		assert.notStrictEqual(cards[0], new Card(23, 6))
 	});
 
 	it('Returns combination of hand given as the only hand with cards', () => {


### PR DESCRIPTION
In debugger, I see that `this.cards` is computed to one card(the highest card in a hand), which is insufficient to compare 2 hands that only consists of high cards. This resulted in incorrect sorting of hand strength and incorrect highestCombination, as observed in issue #9 